### PR TITLE
모달 개선 작업

### DIFF
--- a/frontend/atoms/modalState.ts
+++ b/frontend/atoms/modalState.ts
@@ -1,0 +1,19 @@
+import { atom } from 'recoil';
+
+import type { ModalProps } from '@components/common/Modal';
+
+export const MODAL_TYPES = {
+  Modal: 'Modal',
+} as const;
+
+export interface BasicModalType {
+  modalType: typeof MODAL_TYPES.Modal;
+  modalProps: ModalProps;
+}
+
+export type ModalType = BasicModalType;
+
+export const modalState = atom<ModalType[]>({
+  key: 'modalState',
+  default: [],
+});

--- a/frontend/components/article/ArticleContent/index.tsx
+++ b/frontend/components/article/ArticleContent/index.tsx
@@ -37,7 +37,7 @@ interface ArticleProps {
   bookId: number;
   bookAuthor: string;
   articleData: string;
-  handleScrapBtnClick: () => void;
+  handleScrapModalOpen: () => void;
 }
 
 export default function Article({
@@ -46,7 +46,7 @@ export default function Article({
   bookId,
   bookAuthor,
   articleData,
-  handleScrapBtnClick,
+  handleScrapModalOpen,
 }: ArticleProps) {
   const user = useRecoilValue(signInStatusState);
 
@@ -172,7 +172,7 @@ export default function Article({
                   <ArticleButton onClick={handleScrapDeleteBtnOnClick}>스크랩 삭제</ArticleButton>
                 )}
                 {user.id !== 0 && (
-                  <ArticleButton onClick={handleScrapBtnClick}>
+                  <ArticleButton onClick={handleScrapModalOpen}>
                     <Image src={Scrap} alt="Scrap Icon" width={20} height={15} />
                     스크랩
                   </ArticleButton>

--- a/frontend/components/article/ScrapModal/index.tsx
+++ b/frontend/components/article/ScrapModal/index.tsx
@@ -10,17 +10,19 @@ import DragArticle from '@components/common/DragDrop';
 import Dropdown from '@components/common/Dropdown';
 import ModalButton from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
+import useModal from '@hooks/useModal';
 import { IBook, IArticle, IScrap, IBookScraps } from '@interfaces';
 import { toastSuccess } from '@utils/toast';
 
 import { ArticleWrapper, DragArticleText, Label, ScrapModalWrapper, WarningLabel } from './styled';
 
 interface ScrapModalProps {
-  handleModalClose: () => void;
   article: IArticle;
 }
 
-export default function ScrapModal({ handleModalClose, article }: ScrapModalProps) {
+export default function ScrapModal({ article }: ScrapModalProps) {
+  const { closeEveryModal } = useModal();
+
   const [selectedBookIndex, setSelectedBookIndex] = useState(-1);
   const [filteredScraps, setFilteredScraps] = useState<IScrap[]>([]);
   const { data: createScrapData, execute: createScrap } = useFetch(createScrapApi);
@@ -93,7 +95,7 @@ export default function ScrapModal({ handleModalClose, article }: ScrapModalProp
   useEffect(() => {
     if (createScrapData === undefined) return;
     toastSuccess(`${article.title}글이 스크랩되었습니다.`);
-    handleModalClose();
+    closeEveryModal();
   }, [createScrapData]);
 
   return (

--- a/frontend/components/auth/SignInModal/index.tsx
+++ b/frontend/components/auth/SignInModal/index.tsx
@@ -12,14 +12,10 @@ import useFetch from '@hooks/useFetch';
 import { SignInModalWrapper, SignUpContainer, SignUpButton } from './styled';
 
 interface SignInModalProps {
-  handleGoToSignUpBtnClicked: () => void;
-  handleModalClose: () => void;
+  handleSignUpModalOpen: () => void;
 }
 
-export default function SignInModal({
-  handleGoToSignUpBtnClicked,
-  handleModalClose,
-}: SignInModalProps) {
+export default function SignInModal({ handleSignUpModalOpen }: SignInModalProps) {
   const [info, setInfo] = useState({
     username: '',
     password: '',
@@ -50,7 +46,6 @@ export default function SignInModal({
   useEffect(() => {
     if (!user) return;
 
-    handleModalClose();
     router.reload();
   }, [user]);
 
@@ -75,11 +70,11 @@ export default function SignInModal({
       </Button>
       <Button theme="second" onClick={handleSignInGithubClick}>
         <Image src={GithubIcon} alt="Github Icon" />
-        Github으로 로그인하기
+        GitHub으로 로그인하기
       </Button>
       <SignUpContainer>
         <div>아직 계정이 없으신가요?</div>
-        <SignUpButton onClick={handleGoToSignUpBtnClicked}>회원가입하기</SignUpButton>
+        <SignUpButton onClick={handleSignUpModalOpen}>회원가입하기</SignUpButton>
       </SignUpContainer>
     </SignInModalWrapper>
   );

--- a/frontend/components/auth/SignUpModal/index.tsx
+++ b/frontend/components/auth/SignUpModal/index.tsx
@@ -4,15 +4,14 @@ import { createUserApi } from '@apis/authApi';
 import LabeledInput from '@components/common/LabeledInput';
 import Button from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
+import useModal from '@hooks/useModal';
 import { toastSuccess } from '@utils/toast';
 
 import { SignUpModalWrapper, SignUpModalErrorMessage } from './styled';
 
-interface SignUpModalProps {
-  handleModalClose: () => void;
-}
+function SignUpModal() {
+  const { closeEveryModal } = useModal();
 
-function SignUpModal({ handleModalClose }: SignUpModalProps) {
   const [errorMessage, setErrorMessage] = useState('');
   const [isInputValid, setIsInputValid] = useState(false);
   const [info, setInfo] = useState({
@@ -24,8 +23,8 @@ function SignUpModal({ handleModalClose }: SignUpModalProps) {
 
   useEffect(() => {
     if (createUserData === undefined) return;
-    handleModalClose();
     toastSuccess('Knoticle 가입을 축하합니다!');
+    closeEveryModal();
   }, [createUserData]);
 
   const checkUsernameValid = (username: string) => {

--- a/frontend/components/common/GNB/index.tsx
+++ b/frontend/components/common/GNB/index.tsx
@@ -31,7 +31,7 @@ export default function GNB({ delta }: GNBProps) {
     setCurrentModalState('SignIn');
   };
   const handleGoToSignUpBtnClicked = () => setCurrentModalState('SignUp');
-  const handleBackwardBtnClicked = () => setCurrentModalState('SignIn');
+  const handleBackwardClick = () => setCurrentModalState('SignIn');
 
   return (
     <GNBContainer delta={delta}>
@@ -62,7 +62,7 @@ export default function GNB({ delta }: GNBProps) {
           <Modal
             title="Knoticle 함께하기"
             handleModalClose={handleModalClose}
-            handleBackwardBtnClicked={handleBackwardBtnClicked}
+            handleBackwardClick={handleBackwardClick}
             hasBackward
           >
             <SignUpModal handleModalClose={handleModalClose} />

--- a/frontend/components/common/GNB/index.tsx
+++ b/frontend/components/common/GNB/index.tsx
@@ -1,14 +1,13 @@
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 
-import { useState } from 'react';
-
 import { useRecoilValue } from 'recoil';
 
 import ArticleIcon from '@assets/ico_article.svg';
 import PersonIcon from '@assets/ico_person.svg';
 import SearchIcon from '@assets/ico_search.svg';
 import signInStatusState from '@atoms/signInStatus';
+import useModal from '@hooks/useModal';
 
 import { GNBContainer, Icon, IconWrapper, Logo, LogoWrapper } from './styled';
 
@@ -17,21 +16,33 @@ interface GNBProps {
 }
 
 export default function GNB({ delta }: GNBProps) {
-  const Modal = dynamic(() => import('@components/common/Modal'));
   const SignInModal = dynamic(() => import('@components/auth/SignInModal'));
   const SignUpModal = dynamic(() => import('@components/auth/SignUpModal'));
 
-  const [isModalShown, setModalShown] = useState(false);
-  const [currentModalState, setCurrentModalState] = useState<'SignIn' | 'SignUp'>('SignIn');
   const signInStatus = useRecoilValue(signInStatusState);
 
-  const handleModalOpen = () => setModalShown(true);
-  const handleModalClose = () => {
-    setModalShown(false);
-    setCurrentModalState('SignIn');
+  const { openModal } = useModal();
+
+  const handleSignUpModalOpen = () => {
+    openModal({
+      modalType: 'Modal',
+      modalProps: {
+        title: 'Knoticle 함께하기',
+        hasBackward: true,
+        children: <SignUpModal />,
+      },
+    });
   };
-  const handleGoToSignUpBtnClicked = () => setCurrentModalState('SignUp');
-  const handleBackwardClick = () => setCurrentModalState('SignIn');
+
+  const handleSignInModalOpen = () => {
+    openModal({
+      modalType: 'Modal',
+      modalProps: {
+        title: 'Knoticle 시작하기',
+        children: <SignInModal handleSignUpModalOpen={handleSignUpModalOpen} />,
+      },
+    });
+  };
 
   return (
     <GNBContainer delta={delta}>
@@ -50,31 +61,12 @@ export default function GNB({ delta }: GNBProps) {
             </Link>
           </>
         ) : (
-          <Icon src={PersonIcon} alt="Person Icon" onClick={handleModalOpen} />
+          <Icon src={PersonIcon} alt="Person Icon" onClick={handleSignInModalOpen} />
         )}
         <Link href="/search">
           <Icon src={SearchIcon} alt="Search Icon" />
         </Link>
       </IconWrapper>
-
-      {isModalShown &&
-        ((currentModalState === 'SignUp' && (
-          <Modal
-            title="Knoticle 함께하기"
-            handleModalClose={handleModalClose}
-            handleBackwardClick={handleBackwardClick}
-            hasBackward
-          >
-            <SignUpModal handleModalClose={handleModalClose} />
-          </Modal>
-        )) || (
-          <Modal title="Knoticle 시작하기" handleModalClose={handleModalClose}>
-            <SignInModal
-              handleGoToSignUpBtnClicked={handleGoToSignUpBtnClicked}
-              handleModalClose={handleModalClose}
-            />
-          </Modal>
-        ))}
     </GNBContainer>
   );
 }

--- a/frontend/components/common/GNB/styled.ts
+++ b/frontend/components/common/GNB/styled.ts
@@ -19,7 +19,7 @@ export const GNBContainer = styled.div<GNBContainerProps>`
   top: 0;
   box-shadow: rgb(0 0 0 / 16%) 0px 0px 8px;
   box-sizing: border-box;
-  z-index: 100;
+  z-index: 150;
   transform: translateY(${(props) => -props.delta}px);
 `;
 

--- a/frontend/components/common/GlobalModal/index.tsx
+++ b/frontend/components/common/GlobalModal/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { useRecoilValue } from 'recoil';
+
+import { modalState, MODAL_TYPES } from '@atoms/modalState';
+import Modal from '@components/common/Modal';
+
+const MODAL_COMPONENTS: any = {
+  [MODAL_TYPES.Modal]: Modal,
+};
+
+export default function GlobalModal() {
+  const { modalType, modalProps } = useRecoilValue(modalState).at(-1) || {};
+
+  if (!modalType) return null;
+
+  const renderModal = () => {
+    const ModalComponent = MODAL_COMPONENTS[modalType];
+
+    return <ModalComponent {...modalProps} />;
+  };
+
+  return <>{renderModal()}</>;
+}

--- a/frontend/components/common/Modal/index.tsx
+++ b/frontend/components/common/Modal/index.tsx
@@ -2,32 +2,26 @@ import Image from 'next/image';
 
 import BackwardIcon from '@assets/ico_backward.svg';
 import CancelIcon from '@assets/ico_cancel.svg';
+import useModal from '@hooks/useModal';
 
 import { ButtonWrapper, Dimmed, ModalContainer, ModalInner, ModalTitle } from './styled';
 
-interface ModalProps {
+export interface ModalProps {
   title: string;
-  hasBackward?: boolean;
   children: React.ReactNode;
-
-  handleModalClose: () => void;
-  handleBackwardClick?: () => void;
+  hasBackward?: boolean;
 }
 
-export default function Modal({
-  title,
-  hasBackward,
-  children,
-  handleModalClose,
-  handleBackwardClick,
-}: ModalProps) {
+export default function Modal({ title, hasBackward, children }: ModalProps) {
+  const { closeModal, closeEveryModal } = useModal();
+
   return (
     <ModalContainer>
-      <Dimmed onClick={handleModalClose} />
+      <Dimmed onClick={closeEveryModal} />
       <ModalInner>
         <ButtonWrapper hasBackward={hasBackward}>
-          <Image src={BackwardIcon} alt="Backward Icon" onClick={handleBackwardClick} />
-          <Image src={CancelIcon} alt="Cancel Icon" onClick={handleModalClose} />
+          <Image src={BackwardIcon} alt="Backward Icon" onClick={closeModal} />
+          <Image src={CancelIcon} alt="Cancel Icon" onClick={closeEveryModal} />
         </ButtonWrapper>
         <ModalTitle>{title}</ModalTitle>
         {children}
@@ -38,5 +32,4 @@ export default function Modal({
 
 Modal.defaultProps = {
   hasBackward: false,
-  handleBackwardClick: undefined,
 };

--- a/frontend/components/common/Modal/index.tsx
+++ b/frontend/components/common/Modal/index.tsx
@@ -2,9 +2,8 @@ import Image from 'next/image';
 
 import BackwardIcon from '@assets/ico_backward.svg';
 import CancelIcon from '@assets/ico_cancel.svg';
-import { TextLinkMedium } from '@styles/common';
 
-import { ButtonWrapper, Dimmed, ModalInner, ModalTitle, ModalWrapper } from './styled';
+import { ButtonWrapper, Dimmed, ModalContainer, ModalInner, ModalTitle } from './styled';
 
 interface ModalProps {
   title: string;
@@ -12,7 +11,7 @@ interface ModalProps {
   children: React.ReactNode;
 
   handleModalClose: () => void;
-  handleBackwardBtnClicked?: () => void;
+  handleBackwardClick?: () => void;
 }
 
 export default function Modal({
@@ -20,26 +19,24 @@ export default function Modal({
   hasBackward,
   children,
   handleModalClose,
-  handleBackwardBtnClicked,
+  handleBackwardClick,
 }: ModalProps) {
   return (
-    <ModalWrapper>
+    <ModalContainer>
       <Dimmed onClick={handleModalClose} />
       <ModalInner>
         <ButtonWrapper hasBackward={hasBackward}>
-          <Image src={BackwardIcon} alt="Backward Icon" onClick={handleBackwardBtnClicked} />
+          <Image src={BackwardIcon} alt="Backward Icon" onClick={handleBackwardClick} />
           <Image src={CancelIcon} alt="Cancel Icon" onClick={handleModalClose} />
         </ButtonWrapper>
-        <ModalTitle>
-          <TextLinkMedium>{title}</TextLinkMedium>
-        </ModalTitle>
+        <ModalTitle>{title}</ModalTitle>
         {children}
       </ModalInner>
-    </ModalWrapper>
+    </ModalContainer>
   );
 }
 
 Modal.defaultProps = {
   hasBackward: false,
-  handleBackwardBtnClicked: undefined,
+  handleBackwardClick: undefined,
 };

--- a/frontend/components/common/Modal/styled.ts
+++ b/frontend/components/common/Modal/styled.ts
@@ -1,5 +1,8 @@
 import styled from 'styled-components';
 
+import { TextLinkMedium } from '@styles/common';
+import { FlexCenter } from '@styles/layout';
+
 export const Dimmed = styled.div`
   position: fixed;
   top: 0px;
@@ -9,28 +12,30 @@ export const Dimmed = styled.div`
   background-color: rgba(0, 0, 0, 0.3);
 `;
 
-export const ModalWrapper = styled.div`
+export const ModalContainer = styled(FlexCenter)`
   position: fixed;
   top: 0px;
   left: 0px;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 99;
+  width: 100vw;
+  height: 100vh;
+  z-index: 200;
 `;
 
 export const ModalInner = styled.div`
   width: 360px;
   padding: 32px;
   background: var(--white-color);
-  border-radius: 30px;
-  z-index: 100;
+  border-radius: 24px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  box-sizing: border-box;
 
   @media ${(props) => props.theme.mobile} {
-    width: 320px;
-    padding: 32px 20px;
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
   }
 `;
 
@@ -43,6 +48,6 @@ export const ButtonWrapper = styled.div<{ hasBackward?: boolean }>`
   }
 `;
 
-export const ModalTitle = styled.div`
+export const ModalTitle = styled(TextLinkMedium)`
   text-align: center;
 `;

--- a/frontend/components/edit/ModifyModal/index.tsx
+++ b/frontend/components/edit/ModifyModal/index.tsx
@@ -19,7 +19,7 @@ import { ArticleWrapper, DragArticleText, Label, ModifyModalWrapper, WarningLabe
 
 interface ModifyModalProps {
   books: IBookScraps[];
-  originalArticle: IArticleBook;
+  originalArticle: IArticleBook | undefined;
 }
 
 export default function ModifyModal({ books, originalArticle }: ModifyModalProps) {
@@ -100,7 +100,10 @@ export default function ModifyModal({ books, originalArticle }: ModifyModalProps
     if (modifiedArticle) {
       const { title } = modifiedArticle.modifiedArticle;
       router.push(
-        `/@${originalArticle.book.user.nickname}/${encodeURL(originalArticle.book.title, title)}`
+        `/@${originalArticle?.book.user.nickname}/${encodeURL(
+          originalArticle?.book.title || '',
+          title
+        )}`
       );
       toastSuccess(`${title}글이 수정되었습니다.`);
     }

--- a/frontend/components/shelf/AddBook/index.tsx
+++ b/frontend/components/shelf/AddBook/index.tsx
@@ -9,6 +9,7 @@ import signInStatusState from '@atoms/signInStatus';
 import Button from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
+import useModal from '@hooks/useModal';
 import { FlexSpaceBetween } from '@styles/layout';
 import { toastError, toastSuccess } from '@utils/toast';
 
@@ -25,11 +26,9 @@ import {
   BookContent,
 } from './styled';
 
-interface AddBookProps {
-  handleModalClose: () => void;
-}
+export default function AddBook() {
+  const { closeEveryModal } = useModal();
 
-export default function AddBook({ handleModalClose }: AddBookProps) {
   const [curKnottedBookList, setCurKnottedBookList] = useRecoilState(curKnottedBookListState);
   const user = useRecoilValue(signInStatusState);
   const title = useInput('');
@@ -38,7 +37,7 @@ export default function AddBook({ handleModalClose }: AddBookProps) {
   useEffect(() => {
     if (!addBookData) return;
     setCurKnottedBookList([...curKnottedBookList, addBookData]);
-    handleModalClose();
+    closeEveryModal();
     toastSuccess(`<${addBookData.title}>책이 생성되었습니다!`);
   }, [addBookData]);
 

--- a/frontend/components/shelf/BookListTab/index.tsx
+++ b/frontend/components/shelf/BookListTab/index.tsx
@@ -7,8 +7,8 @@ import curKnottedBookListState from '@atoms/curKnottedBookList';
 import editInfoState from '@atoms/editInfo';
 import scrapState from '@atoms/scrap';
 import Book from '@components/common/Book';
-import Modal from '@components/common/Modal';
 import FAB from '@components/shelf/FAB';
+import useModal from '@hooks/useModal';
 import { IBookScraps } from '@interfaces';
 
 import EditBookModal from '../EditBookModal';
@@ -35,12 +35,12 @@ export default function BookListTab({
   bookmarkedBookList,
   isUserMatched,
 }: BookListTabProps) {
+  const { openModal } = useModal();
+
   const [curKnottedBookList, setCurKnottedBookList] = useRecoilState(curKnottedBookListState);
   const [editInfo, setEditInfo] = useRecoilState(editInfoState);
   const setScraps = useSetRecoilState(scrapState);
 
-  const [isModalShown, setModalShown] = useState(false);
-  const [curEditBook, setCurEditBook] = useState<IBookScraps | null>(null);
   const [tabStatus, setTabStatus] = useState<'knotted' | 'bookmarked'>('knotted');
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
@@ -48,14 +48,15 @@ export default function BookListTab({
     const curBook = knottedBookList?.find((v) => v.id === id);
     if (!curBook) return;
 
-    setModalShown(true);
-    setCurEditBook(curBook);
-    setScraps(curBook.scraps);
-  };
+    openModal({
+      modalType: 'Modal',
+      modalProps: {
+        title: '내 책 수정하기',
+        children: curBook && <EditBookModal book={curBook} />,
+      },
+    });
 
-  const handleModalClose = () => {
-    setModalShown(false);
-    setScraps([]);
+    setScraps(curBook.scraps);
   };
 
   const handleMinusBtnClick = (e: React.MouseEvent<HTMLButtonElement>, id: number) => {
@@ -137,12 +138,6 @@ export default function BookListTab({
 
       {isUserMatched && tabStatus === 'knotted' && (
         <FAB isEditing={isEditing} setIsEditing={setIsEditing} />
-      )}
-
-      {isModalShown && (
-        <Modal title="내 책 수정하기" handleModalClose={handleModalClose}>
-          {curEditBook && <EditBookModal book={curEditBook} handleModalClose={handleModalClose} />}
-        </Modal>
       )}
     </BookListTabWrapper>
   );

--- a/frontend/components/shelf/EditBookModal/index.tsx
+++ b/frontend/components/shelf/EditBookModal/index.tsx
@@ -13,6 +13,7 @@ import DragArticle from '@components/common/DragDrop';
 import Button from '@components/common/Modal/ModalButton';
 import useFetch from '@hooks/useFetch';
 import useInput from '@hooks/useInput';
+import useModal from '@hooks/useModal';
 import { IBookScraps } from '@interfaces';
 import { FlexSpaceBetween } from '@styles/layout';
 import { toastError } from '@utils/toast';
@@ -37,10 +38,11 @@ import {
 
 interface BookProps {
   book: IBookScraps;
-  handleModalClose: () => void;
 }
 
-export default function EditBookModal({ book, handleModalClose }: BookProps) {
+export default function EditBookModal({ book }: BookProps) {
+  const { closeEveryModal } = useModal();
+
   const { id, title, user } = book;
 
   const { data: imgFile, execute: createImage } = useFetch(createImageApi);
@@ -106,7 +108,7 @@ export default function EditBookModal({ book, handleModalClose }: BookProps) {
         },
       ],
     });
-    handleModalClose();
+    closeEveryModal();
   };
 
   const handleContentsOnClick = () => {

--- a/frontend/components/shelf/FAB/index.tsx
+++ b/frontend/components/shelf/FAB/index.tsx
@@ -1,7 +1,5 @@
 import Image from 'next/image';
 
-import { useState } from 'react';
-
 import { useRecoilState } from 'recoil';
 
 import { deleteArticleApi } from '@apis/articleApi';
@@ -11,8 +9,8 @@ import Add from '@assets/ico_add.svg';
 import CheckWhite from '@assets/ico_check_white.svg';
 import EditWhite from '@assets/ico_edit_white.svg';
 import editInfoState from '@atoms/editInfo';
-import Modal from '@components/common/Modal';
 import useFetch from '@hooks/useFetch';
+import useModal from '@hooks/useModal';
 import { toastSuccess } from '@utils/toast';
 
 import AddBook from '../AddBook';
@@ -24,6 +22,8 @@ interface FabProps {
 }
 
 export default function FAB({ isEditing, setIsEditing }: FabProps) {
+  const { openModal } = useModal();
+
   const { execute: deleteBook } = useFetch(deleteBookApi);
   const { execute: editBook } = useFetch(editBookApi);
   const { execute: deleteArticle } = useFetch(deleteArticleApi);
@@ -36,13 +36,14 @@ export default function FAB({ isEditing, setIsEditing }: FabProps) {
 
   const [editInfo, setEditInfo] = useRecoilState(editInfoState);
 
-  const [isModalShown, setModalShown] = useState(false);
-
-  const handleModalOpen = () => {
-    setModalShown(true);
-  };
-  const handleModalClose = () => {
-    setModalShown(false);
+  const handleCreateBookModalOpen = () => {
+    openModal({
+      modalType: 'Modal',
+      modalProps: {
+        title: '책 추가하기',
+        children: <AddBook />,
+      },
+    });
   };
 
   const handleEditFinishBtnClick = () => {
@@ -124,7 +125,7 @@ export default function FAB({ isEditing, setIsEditing }: FabProps) {
 
   return (
     <FabWrapper>
-      <FabButton onClick={handleModalOpen}>
+      <FabButton onClick={handleCreateBookModalOpen}>
         <Image src={Add} alt="책 추가" />
       </FabButton>
 
@@ -140,11 +141,6 @@ export default function FAB({ isEditing, setIsEditing }: FabProps) {
         >
           <Image src={EditWhite} alt="책 수정" />
         </FabButton>
-      )}
-      {isModalShown && (
-        <Modal title="책 추가하기" handleModalClose={handleModalClose}>
-          <AddBook handleModalClose={handleModalClose} />
-        </Modal>
       )}
     </FabWrapper>
   );

--- a/frontend/hooks/useModal.ts
+++ b/frontend/hooks/useModal.ts
@@ -1,0 +1,28 @@
+import { useRecoilState } from 'recoil';
+
+import { modalState } from '@atoms/modalState';
+import type { ModalType } from '@atoms/modalState';
+
+export default function useModal() {
+  const [modal, setModal] = useRecoilState(modalState);
+
+  const openModal = ({ modalType, modalProps }: ModalType) => {
+    setModal((prev) => prev.concat({ modalType, modalProps }));
+  };
+
+  const closeModal = () => {
+    setModal((prev) => [...prev.slice(0, prev.length - 1)]);
+  };
+
+  const closeEveryModal = () => {
+    setModal([]);
+  };
+
+  return {
+    modal,
+    setModal,
+    openModal,
+    closeModal,
+    closeEveryModal,
+  };
+}

--- a/frontend/pages/[nickname]/[book]/[article].tsx
+++ b/frontend/pages/[nickname]/[book]/[article].tsx
@@ -11,6 +11,7 @@ import Sidebar from '@components/article/Sidebar';
 import ViewerHead from '@components/article/ViewerHead';
 import HeaderLayout from '@components/layout/HeaderLayout';
 import useFetch from '@hooks/useFetch';
+import useModal from '@hooks/useModal';
 import { IArticleBook, IBookScraps } from '@interfaces';
 import { Flex } from '@styles/layout';
 import { parseHeadings } from '@utils/toc';
@@ -20,18 +21,25 @@ interface ArticlePageProps {
 }
 
 export default function ArticlePage({ article }: ArticlePageProps) {
-  const Modal = dynamic(() => import('@components/common/Modal'));
   const ScrapModal = dynamic(() => import('@components/article/ScrapModal'));
 
   const router = useRouter();
 
+  const { openModal } = useModal();
+
   const { data: book, execute: getBook } = useFetch<IBookScraps>(getBookApi);
 
   const [isSideBarOpen, setSideBarOpen] = useState(false);
-  const [isModalShown, setModalShown] = useState(false);
 
-  const handleModalOpen = () => setModalShown(true);
-  const handleModalClose = () => setModalShown(false);
+  const handleModalOpen = () => {
+    openModal({
+      modalType: 'Modal',
+      modalProps: {
+        title: '글 스크랩하기',
+        children: <ScrapModal article={article} />,
+      },
+    });
+  };
 
   const handleSideBarToggle = () => {
     setSideBarOpen((prev) => !prev);
@@ -90,11 +98,6 @@ export default function ArticlePage({ article }: ArticlePageProps) {
             />
           )}
         </Flex>
-      )}
-      {isModalShown && book && (
-        <Modal title="글 스크랩하기" handleModalClose={handleModalClose}>
-          <ScrapModal handleModalClose={handleModalClose} article={article} />
-        </Modal>
       )}
     </>
   );

--- a/frontend/pages/[nickname]/[book]/[article].tsx
+++ b/frontend/pages/[nickname]/[book]/[article].tsx
@@ -31,7 +31,7 @@ export default function ArticlePage({ article }: ArticlePageProps) {
 
   const [isSideBarOpen, setSideBarOpen] = useState(false);
 
-  const handleModalOpen = () => {
+  const handleScrapModalOpen = () => {
     openModal({
       modalType: 'Modal',
       modalProps: {
@@ -94,7 +94,7 @@ export default function ArticlePage({ article }: ArticlePageProps) {
               bookId={book.id}
               bookAuthor={book.user.nickname}
               articleData={article.content}
-              handleScrapBtnClick={handleModalOpen}
+              handleScrapModalOpen={handleScrapModalOpen}
             />
           )}
         </Flex>

--- a/frontend/pages/[nickname]/index.tsx
+++ b/frontend/pages/[nickname]/index.tsx
@@ -17,7 +17,7 @@ import StudyHead from '@components/shelf/StudyHead';
 import UserProfile from '@components/shelf/UserProfile';
 import useFetch from '@hooks/useFetch';
 import { IUser } from '@interfaces';
-import { PageInnerLarge, PageWrapper } from '@styles/layout';
+import { PageInnerLarge } from '@styles/layout';
 
 interface ShelfPageProps {
   userProfile: {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -8,6 +8,7 @@ import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 
 import CheckSignInStatus from '@components/auth/CheckSignInStatus';
+import GlobalModal from '@components/common/GlobalModal';
 import GlobalStyle from '@styles/GlobalStyle';
 import responsive from '@styles/responsive';
 
@@ -32,6 +33,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
         <ThemeProvider theme={responsive}>
           {getLayout(<Component {...pageProps} />)}
           <ToastContainer limit={3} />
+          <GlobalModal />
         </ThemeProvider>
       </CheckSignInStatus>
     </RecoilRoot>

--- a/frontend/pages/write.tsx
+++ b/frontend/pages/write.tsx
@@ -11,22 +11,20 @@ import signInStatusState from '@atoms/signInStatus';
 import EditHead from '@components/edit/EditHead';
 import Editor from '@components/edit/Editor';
 import useFetch from '@hooks/useFetch';
+import useModal from '@hooks/useModal';
 import { IArticleBook } from '@interfaces';
 import { PageNoScrollWrapper } from '@styles/layout';
 import { toastError } from '@utils/toast';
 
 export default function WritePage() {
-  const Modal = dynamic(() => import('@components/common/Modal'));
   const PublishModal = dynamic(() => import('@components/edit/PublishModal'));
   const ModifyModal = dynamic(() => import('@components/edit/ModifyModal'));
 
   const router = useRouter();
 
-  const [isModalShown, setModalShown] = useState(false);
-  const [originalArticle, setOriginalArticle] = useState<IArticleBook | undefined>(undefined);
+  const { openModal } = useModal();
 
-  const handleModalOpen = () => setModalShown(true);
-  const handleModalClose = () => setModalShown(false);
+  const [originalArticle, setOriginalArticle] = useState<IArticleBook | undefined>(undefined);
 
   const { data: books, execute: getUserKnottedBooks } = useFetch(getUserKnottedBooksApi);
   const { data: article, execute: getArticle } = useFetch(getArticleApi);
@@ -35,6 +33,26 @@ export default function WritePage() {
 
   const syncHeight = () => {
     document.documentElement.style.setProperty('--window-inner-height', `${window.innerHeight}px`);
+  };
+
+  const handleCreateArticleModalOpen = () => {
+    openModal({
+      modalType: 'Modal',
+      modalProps: {
+        title: '글 발행하기',
+        children: <PublishModal books={books} />,
+      },
+    });
+  };
+
+  const handleUpdateArticleModalOpen = () => {
+    openModal({
+      modalType: 'Modal',
+      modalProps: {
+        title: '글 수정하기',
+        children: <ModifyModal books={books} originalArticle={originalArticle} />,
+      },
+    });
   };
 
   useEffect(() => {
@@ -67,18 +85,12 @@ export default function WritePage() {
   return (
     <PageNoScrollWrapper>
       <EditHead />
-      <Editor handleModalOpen={handleModalOpen} originalArticle={originalArticle} />
-
-      {isModalShown &&
-        ((originalArticle && (
-          <Modal title="글 수정하기" handleModalClose={handleModalClose}>
-            <ModifyModal books={books} originalArticle={originalArticle} />
-          </Modal>
-        )) || (
-          <Modal title="글 발행하기" handleModalClose={handleModalClose}>
-            <PublishModal books={books} />
-          </Modal>
-        ))}
+      <Editor
+        handleModalOpen={
+          originalArticle ? handleUpdateArticleModalOpen : handleCreateArticleModalOpen
+        }
+        originalArticle={originalArticle}
+      />
     </PageNoScrollWrapper>
   );
 }


### PR DESCRIPTION
## 개요

기존 모달 컴포넌트의 스타일을 수정하고, 전역 상태로 모달을 관리할 수 있도록 했습니다.

## 변경 사항

- GlobalModal 컴포넌트 추가
- useModal 훅 추가
- modalState Recoil 상태 추가
- 모달 컴포넌트 스타일 수정
  - 모바일 환경에서 모달 컴포넌트가 화면 전체를 차지하도록 개선

## 참고 사항

- 모달을 전역 상태로 관리하려는 이유는 다음과 같습니다.
  - 컴포넌트에서 모달을 사용하기 위해서는 매번 모달 컴포넌트와 내부에 들어가는 컴포넌트를 불러와야합니다. 이는 중복되는 코드량을 늘리고, 모달 내부 수정이 발생할 때마다 모든 모달 코드를 찾아서 수정해줘야하는 번거로움이 생깁니다.
  - 기존에는 모달을 열고 닫는 이벤트 핸들러 함수를 모달을 사용하는 모든 컴포넌트에서 생성해준 후 모달 컴포넌트에 내려줬습니다. 이는 컴포넌트와 모달 컴포넌트를 강결합시키게 되어 각 컴포넌트에서 모달의 상태를 관리해야하는 불필요한 책임이 생깁니다.
  - 따라서 modalState 전역 상태를 생성하여 모달을 한 군데서 관리할 수 있도록 개선했습니다. 또한 useModal 훅을 통해서 상태를 관리할 수 있도록 개선했습니다. 이제 각 컴포넌트는 모달의 상태를 신경쓰지 않고, 각자의 비즈니스 로직에 집중할 수 있게 되었습니다.
- 모달의 전역 상태를 배열로 관리해서 여러 모달이 생기는 경우를 대응할 수 있게 되었습니다.
  - 예를 들어서 로그인 모달 <-> 회원가입 모달은 두 개의 모달이 나타나는 경우이며, GNB 컴포넌트에서 어떤 모달이 열렸는지 관리해줘야했습니다.
  - 하지만 모달의 전역 상태를 배열로 생성하고, 모달이 열릴 때마다 배열에 모달을 추가해주는 방식으로 관리하면 GlobalModal 컴포넌트에서는 배열의 마지막 모달만 보여주면되기 때문에 앞선 상태 관리를 손쉽게 할 수 있게 됩니다.

```
// modalState

[ ] - 초기 상태
[ signInModal ] - 로그인 모달을 연 상태
[ signInModal, signUpModal ] - 로그인 모달에서 회원가입 모달을 연 상태
[ signInModal ] - 회원가입 모달에서 뒤로가기 버튼을 누른 상태
```

## 관련 이슈

- close #8 
