### PR TITLE
글 페이지 React Query 적용 및 SSR 적용 작업

### DIFF
--- a/backend/src/apis/articles/articles.controller.ts
+++ b/backend/src/apis/articles/articles.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 
-import { SearchArticles } from '@apis/articles/articles.interface';
+import { GetArticle, SearchArticles } from '@apis/articles/articles.interface';
 import articlesService from '@apis/articles/articles.service';
 import { IScrap } from '@apis/scraps/scraps.interface';
 import scrapsService from '@apis/scraps/scraps.service';
@@ -25,12 +25,13 @@ const searchArticles = async (req: Request, res: Response) => {
 };
 
 const getArticle = async (req: Request, res: Response) => {
-  const { id, title } = req.query as unknown as {
-    id: string;
-    title: string;
-  };
+  const { articleTitle, bookTitle, owner } = req.query as unknown as GetArticle;
 
-  const article = await articlesService.getArticle({ id: +id, title });
+  const article = await articlesService.getArticle({
+    articleTitle,
+    bookTitle,
+    owner,
+  });
 
   return res.status(200).send(article);
 };

--- a/backend/src/apis/articles/articles.interface.ts
+++ b/backend/src/apis/articles/articles.interface.ts
@@ -7,8 +7,9 @@ export interface SearchArticles {
 }
 
 export interface GetArticle {
-  id?: number;
-  title?: string;
+  articleTitle: string;
+  bookTitle: string;
+  owner: string;
 }
 
 export interface CreateArticle {

--- a/backend/src/apis/articles/articles.service.ts
+++ b/backend/src/apis/articles/articles.service.ts
@@ -68,21 +68,9 @@ const searchArticles = async (searchArticles: SearchArticles) => {
   };
 };
 
-const getArticle = async ({ id, title }: GetArticle) => {
+const getArticle = async ({ articleTitle, bookTitle, owner }: GetArticle) => {
   const article = await prisma.article.findFirst({
-    where: {
-      OR: {
-        id: id ? id : undefined,
-        title,
-      },
-    },
-    select: {
-      id: true,
-      title: true,
-      content: true,
-      created_at: true,
-      deleted_at: true,
-      book_id: true,
+    include: {
       book: {
         select: {
           title: true,
@@ -90,6 +78,19 @@ const getArticle = async ({ id, title }: GetArticle) => {
             select: {
               id: true,
               nickname: true,
+            },
+          },
+        },
+      },
+    },
+    where: {
+      title: articleTitle,
+      scraps: {
+        some: {
+          book: {
+            title: bookTitle,
+            user: {
+              nickname: owner,
             },
           },
         },

--- a/backend/src/apis/books/books.controller.ts
+++ b/backend/src/apis/books/books.controller.ts
@@ -18,6 +18,17 @@ const getBook = async (req: Request, res: Response) => {
   return res.status(200).send(book);
 };
 
+const getOwnerBook = async (req: Request, res: Response) => {
+  const { title, owner } = req.query as unknown as {
+    title: string;
+    owner: string;
+  };
+
+  const book = await booksService.getOwnerBook({ title, owner });
+
+  return res.status(200).send(book);
+};
+
 const getBooks = async (req: Request, res: Response) => {
   const { order, take, editor, type } = req.query as unknown as FindBooks;
 
@@ -92,6 +103,7 @@ const deleteBook = async (req: Request, res: Response) => {
 
 export default {
   getBook,
+  getOwnerBook,
   getBooks,
   searchBooks,
   createBook,

--- a/backend/src/apis/books/books.interface.ts
+++ b/backend/src/apis/books/books.interface.ts
@@ -6,6 +6,11 @@ export interface SearchBooks {
   isUsers?: string;
 }
 
+export interface GetOwnerBook {
+  title: string;
+  owner: string;
+}
+
 export interface FindBooks {
   order: 'newest' | 'bookmark';
   take: number;

--- a/backend/src/apis/index.ts
+++ b/backend/src/apis/index.ts
@@ -33,6 +33,7 @@ router.delete('/articles/:articleId', guard, catchAsync(articlesController.delet
 router.post('/image', guard, multer().single('image'), catchAsync(imagesController.createImage));
 
 router.get('/books/search', decoder, catchAsync(booksController.searchBooks));
+router.get('/books/owner', catchAsync(booksController.getOwnerBook));
 router.get('/books/:bookId', decoder, catchAsync(booksController.getBook));
 router.get('/books', decoder, catchAsync(booksController.getBooks));
 router.post('/books', guard, catchAsync(booksController.createBook));

--- a/backend/src/config/orm.config.ts
+++ b/backend/src/config/orm.config.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
-export const prisma = new PrismaClient({
-  log: ['query', 'info', 'warn', 'error'],
-});
+export const prisma = new PrismaClient();
+
+// export const prisma = new PrismaClient({
+//   log: ['query', 'info', 'warn', 'error'],
+// });

--- a/frontend/apis/articleApi.ts
+++ b/frontend/apis/articleApi.ts
@@ -22,8 +22,9 @@ export const searchArticlesApi = async (data: SearchArticlesApi) => {
 };
 
 interface GetArticleApi {
-  id?: string;
-  title?: string;
+  articleTitle: string;
+  bookTitle: string;
+  owner: string;
 }
 
 export const getArticleApi = async (data: GetArticleApi) => {

--- a/frontend/apis/bookApi.ts
+++ b/frontend/apis/bookApi.ts
@@ -1,6 +1,40 @@
 import { IScrap } from '@interfaces';
 import api from '@utils/api';
 
+export const getBookApi = async (bookId: string) => {
+  const url = `/api/books/${bookId}`;
+
+  const response = await api({ url, method: 'GET' });
+
+  return response.data;
+};
+
+interface GetOwnerBookApi {
+  title: string;
+  owner: string;
+}
+
+export const getOwnerBookApi = async (data: GetOwnerBookApi) => {
+  const url = `/api/books/owner`;
+
+  const response = await api({ url, method: 'GET', params: data });
+
+  return response.data;
+};
+
+interface GetBooksApi {
+  order: 'newest' | 'bookmark';
+  take: number;
+}
+
+export const getBooksApi = async (data: GetBooksApi) => {
+  const url = `/api/books?order=${data.order}&take=${data.take}`;
+
+  const response = await api({ url, method: 'GET' });
+
+  return response.data;
+};
+
 interface SearchBooksApi {
   query: string;
   isUsers: boolean;
@@ -18,44 +52,6 @@ export const searchBooksApi = async (data: SearchBooksApi) => {
   };
 
   const response = await api({ url, method: 'GET', params });
-
-  return response.data;
-};
-
-interface GetBooksApi {
-  order: 'newest' | 'bookmark';
-  take: number;
-}
-
-interface EditBookApi {
-  id: number;
-  title: string;
-  thumbnail_image: string;
-  scraps: IScrap[];
-}
-
-// NOTE: 서버에서 take가 없을 때 최대로
-
-export const getBooksApi = async (data: GetBooksApi) => {
-  const url = `/api/books?order=${data.order}&take=12`;
-
-  const response = await api({ url, method: 'GET' });
-
-  return response.data;
-};
-
-export const getOrderedBookListApi = async (order: string) => {
-  const url = `/api/books?order=${order}&take=12`;
-
-  const response = await api({ url, method: 'GET' });
-
-  return response.data;
-};
-
-export const getBookApi = async (bookId: string) => {
-  const url = `/api/books/${bookId}`;
-
-  const response = await api({ url, method: 'GET' });
 
   return response.data;
 };
@@ -83,6 +79,13 @@ export const addBookApi = async (data: { title: string }) => {
 
   return response.data;
 };
+
+interface EditBookApi {
+  id: number;
+  title: string;
+  thumbnail_image: string;
+  scraps: IScrap[];
+}
 
 export const editBookApi = async (data: EditBookApi) => {
   const url = `/api/books`;

--- a/frontend/components/article/Sidebar/index.tsx
+++ b/frontend/components/article/Sidebar/index.tsx
@@ -8,9 +8,10 @@ import HideIcon from '@assets/ico_hide.svg';
 import OpenIcon from '@assets/ico_open.svg';
 import IconButton from '@components/common/IconButton';
 import useBookmark from '@hooks/useBookmark';
-import { IBookScraps } from '@interfaces';
+import { IArticleBook, IBookScraps } from '@interfaces';
 import { TextMedium, TextSmall } from '@styles/common';
 import encodeURL from '@utils/encode-url';
+import { parseHeadings } from '@utils/toc';
 
 import {
   ArticleLink,
@@ -29,28 +30,17 @@ import {
   TocArticleTitle,
 } from './styled';
 
-interface Toc {
-  heading: string;
-  link: string;
-  padding: number;
-}
-
 interface SidebarProps {
   book: IBookScraps;
-  articleId: number;
-  headings: Toc[];
+  article: IArticleBook;
   isOpen: boolean;
   handleSideBarToggle: () => void;
 }
 
-export default function Sidebar({
-  articleId,
-  headings,
-  book,
-  isOpen,
-  handleSideBarToggle,
-}: SidebarProps) {
+export default function Sidebar({ book, article, isOpen, handleSideBarToggle }: SidebarProps) {
   const { title, user, scraps } = book;
+  const { id: articleId, content } = article;
+
   const { handleBookmarkClick, curBookmarkCnt, curBookmarkId } = useBookmark(book);
   const [isTocVisible, setTocVisible] = useState(true);
 
@@ -87,7 +77,7 @@ export default function Sidebar({
                   {scrap.order}. {scrap.article.title}
                 </ArticleTitle>
                 {isTocVisible &&
-                  headings.map(({ heading, link, padding }) => (
+                  parseHeadings(content).map(({ heading, link, padding }) => (
                     <TocArticleTitle key={link} href={link} padding={padding}>
                       {heading}
                     </TocArticleTitle>

--- a/frontend/pages/[nickname]/[book]/[article].tsx
+++ b/frontend/pages/[nickname]/[book]/[article].tsx
@@ -1,120 +1,97 @@
 import { GetServerSideProps } from 'next';
-import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 
 import { ReactElement, useEffect, useState } from 'react';
+import { dehydrate, QueryClient, useQuery } from 'react-query';
 
 import { getArticleApi } from '@apis/articleApi';
-import { getBookApi } from '@apis/bookApi';
+import { getOwnerBookApi } from '@apis/bookApi';
 import Article from '@components/article/ArticleContent';
 import Sidebar from '@components/article/Sidebar';
 import ViewerHead from '@components/article/ViewerHead';
 import HeaderLayout from '@components/layout/HeaderLayout';
-import PageLayout from '@components/layout/PageLayout';
-import useFetch from '@hooks/useFetch';
-import useModal from '@hooks/useModal';
+import { DISABLE_REFETCH_OPTIONS } from '@constants/react-query';
 import { IArticleBook, IBookScraps } from '@interfaces';
 import { Flex } from '@styles/layout';
-import { parseHeadings } from '@utils/toc';
 
-interface ArticlePageProps {
-  article: IArticleBook;
-}
-
-export default function ArticlePage({ article }: ArticlePageProps) {
-  const ScrapModal = dynamic(() => import('@components/article/ScrapModal'));
-
+export default function ArticlePage() {
   const router = useRouter();
 
-  const { openModal } = useModal();
-
-  const { data: book, execute: getBook } = useFetch<IBookScraps>(getBookApi);
-
-  const [isSideBarOpen, setSideBarOpen] = useState(false);
-
-  const handleScrapModalOpen = () => {
-    openModal({
-      modalType: 'Modal',
-      modalProps: {
-        title: '글 스크랩하기',
-        children: <ScrapModal article={article} />,
-      },
-    });
+  const {
+    article: articleTitle,
+    book: bookTitle,
+    nickname: owner,
+  } = router.query as {
+    article: string;
+    book: string;
+    nickname: string;
   };
+
+  const { data: book } = useQuery<IBookScraps>(
+    ['getOwnerBook'],
+    () => getOwnerBookApi({ title: bookTitle, owner: owner.slice(1) }),
+    {
+      refetchOnWindowFocus: false,
+    }
+  );
+  const { data: article } = useQuery<IArticleBook>(
+    ['getArticle'],
+    () => getArticleApi({ articleTitle, bookTitle, owner: owner.slice(1) }),
+    DISABLE_REFETCH_OPTIONS
+  );
+
+  const [isSideBarOpen, setSideBarOpen] = useState(true);
 
   const handleSideBarToggle = () => {
     setSideBarOpen((prev) => !prev);
   };
 
-  const checkArticleAuthority = (targetBook: IBookScraps, id: number) => {
-    if (!targetBook) return false;
-    if (targetBook.scraps.find((scrap) => scrap.article.id === id)) return true;
-    return false;
-  };
-
-  const syncHeight = () => {
-    document.documentElement.style.setProperty('--window-inner-height', `${window.innerHeight}px`);
-  };
-
   useEffect(() => {
-    if (window.innerWidth > 576) setSideBarOpen(true);
-
-    syncHeight();
-
-    window.addEventListener('resize', syncHeight);
-
-    return () => window.removeEventListener('resize', syncHeight);
+    if (window.innerWidth < 576) setSideBarOpen(false);
   }, []);
 
-  useEffect(() => {
-    getBook(article.book_id);
-  }, []);
-
-  useEffect(() => {
-    if (book === undefined) return;
-    if (!checkArticleAuthority(book, article.id)) router.push('/404');
-  }, [book]);
+  if (!book || !article) return null;
 
   return (
     <>
       <ViewerHead articleTitle={article.title} articleContent={article.content} />
-      {book && (
-        <Flex>
-          <Sidebar
-            book={book}
-            articleId={article.id}
-            headings={parseHeadings(article.content)}
-            isOpen={isSideBarOpen}
-            handleSideBarToggle={handleSideBarToggle}
-          />
-          {book.scraps.find((scrap) => scrap.article.id === article.id) && (
-            <Article
-              article={article}
-              scraps={book.scraps}
-              bookId={book.id}
-              bookAuthor={book.user.nickname}
-              articleData={article.content}
-              handleScrapModalOpen={handleScrapModalOpen}
-            />
-          )}
-        </Flex>
-      )}
+      <Flex>
+        <Sidebar
+          book={book}
+          article={article}
+          isOpen={isSideBarOpen}
+          handleSideBarToggle={handleSideBarToggle}
+        />
+        <Article book={book} article={article} />
+      </Flex>
     </>
   );
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { article: articleTitle } = context.query as { [key: string]: string };
+  const {
+    article: articleTitle,
+    book: bookTitle,
+    nickname: owner,
+  } = context.query as {
+    article: string;
+    book: string;
+    nickname: string;
+  };
 
-  const article = await getArticleApi({ title: articleTitle });
+  const queryClient = new QueryClient();
 
-  return { props: { article } };
+  await queryClient.prefetchQuery(['getArticle'], () =>
+    getArticleApi({ articleTitle, bookTitle, owner: owner.slice(1) })
+  );
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
 };
 
 ArticlePage.getLayout = function getLayout(page: ReactElement) {
-  return (
-    <HeaderLayout>
-      <PageLayout>{page}</PageLayout>
-    </HeaderLayout>
-  );
+  return <HeaderLayout>{page}</HeaderLayout>;
 };

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,8 +1,8 @@
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 
-import type { ReactElement, ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { ReactElement, ReactNode, useState } from 'react';
+import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import { ToastContainer } from 'react-toastify';
 
 import { RecoilRoot } from 'recoil';
@@ -24,21 +24,23 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
-  const queryClient = new QueryClient();
+  const [queryClient] = useState(() => new QueryClient());
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
-        <CheckSignInStatus>
-          <GlobalStyle />
-          <ThemeProvider theme={theme}>
-            {getLayout(<Component {...pageProps} />)}
-            <ToastContainer limit={3} />
-            <GlobalModal />
-          </ThemeProvider>
-        </CheckSignInStatus>
-      </RecoilRoot>
+      <Hydrate state={pageProps.dehydratedState}>
+        <RecoilRoot>
+          <CheckSignInStatus>
+            <GlobalStyle />
+            <ThemeProvider theme={theme}>
+              {getLayout(<Component {...pageProps} />)}
+              <ToastContainer limit={3} />
+              <GlobalModal />
+            </ThemeProvider>
+          </CheckSignInStatus>
+        </RecoilRoot>
+      </Hydrate>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## 개요

글 페이지 일부 React Query를 적용하고, SSR을 적용했습니다.

## 변경 사항

- 글 페이지 일부 React Query 적용
- 글 페이지 SSR 적용
- Article API 수정
- Book API 수정

## 참고 사항

- 글 페이지에 진입했을 때 해당하는 Book 데이터가 필요한데 기존에 사용 중인 `/books GET` 요청을 재사용하는게 어색하다고 판단해서 /books/owner GET` API를 추가했습니다.
  - `/books` 요청은 여러 데이터를 가져오는 요청인데 글 페이지에서는 해당하는 데이터 하나만 필요하기 때문에 API 분리가 필요합니다.
  - 게다가 각 API에서 필요한 쿼리 파라미터가 다른데 재사용하면서 쿼리 파라미터 필터링을 늘어났고, API가 점차 무거워졌습니다.

## 관련 이슈

- close #21
